### PR TITLE
Specify gdk and gtk version

### DIFF
--- a/RecallActivity.py
+++ b/RecallActivity.py
@@ -9,6 +9,12 @@
 # along with this library; if not, write to the Free Software
 # Foundation, 51 Franklin Street, Suite 500 Boston, MA 02110-1335 USA
 
+import gi
+gi.require_version('Gdk', '3.0')
+gi.require_version('Gtk', '3.0')
+from gi.repository import Gtk
+from gi.repository import Gdk
+
 from game import Game
 from sugar3.activity.widgets import StopButton
 from sugar3.activity.widgets import ActivityToolbarButton
@@ -21,10 +27,6 @@ from toolbar_utils import button_factory, radio_factory, label_factory, \
     separator_factory
 from gettext import gettext as _
 import logging
-from gi.repository import Gdk
-from gi.repository import Gtk
-import gi
-gi.require_version('Gtk', '3.0')
 
 
 _logger = logging.getLogger('recall-activity')


### PR DESCRIPTION
The activity is not opening and showing error as right version is not imported:

`ValueError: Namespace Gtk is already loaded with version 4.0`

Full Traceback:
```
/media/psf/Home/Code/sugar/recall/sprites.py:80: PyGIWarning: Gdk was imported without specifying a version first. Use gi.require_version('Gdk', '4.0') before import to ensure that the right version gets loaded.
  from gi.repository import Gdk
/media/psf/Home/Code/sugar/recall/game.py:25: PyGIWarning: Gtk was imported without specifying a version first. Use gi.require_version('Gtk', '4.0') before import to ensure that the right version gets loaded.
  from gi.repository import Gtk
Traceback (most recent call last):
  File "/usr/bin/sugar-activity3", line 5, in <module>
    activityinstance.main()
  File "/usr/lib/python3.9/site-packages/sugar3/activity/activityinstance.py", line 179, in main
    module = __import__(module_name)
  File "/media/psf/Home/Code/sugar/recall/RecallActivity.py", line 12, in <module>
    from game import Game
  File "/media/psf/Home/Code/sugar/recall/game.py", line 26, in <module>
    from sugar3.activity.activity import get_activity_root
  File "/usr/lib/python3.9/site-packages/sugar3/activity/activity.py", line 173, in <module>
    gi.require_version('Gtk', '3.0')
  File "/usr/lib64/python3.9/site-packages/gi/__init__.py", line 117, in require_version
    raise ValueError('Namespace %s is already loaded with version %s' %
ValueError: Namespace Gtk is already loaded with version 4.0
```